### PR TITLE
Allow arrays in Form Data

### DIFF
--- a/Api/FormData.php
+++ b/Api/FormData.php
@@ -7,6 +7,7 @@ use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 
 /**
@@ -98,6 +99,7 @@ class FormData
      * @VirtualProperty
      * @SerializedName("data")
      * @Groups({"fullFormData"})
+     * @throws \JsonException
      */
     public function getData(): array
     {
@@ -108,12 +110,18 @@ class FormData
         foreach ($this->entity->getData() as $key => $dataElement) {
             $data[$key] = [
                 'type' => 'field',
-                'data' => $dataElement,
+                'data' => is_array($dataElement) ? $this->getDataAsJsonElement($dataElement) : $dataElement,
                 'label' => $key
             ];
         }
         ksort($data);
         return array_values($data);
+    }
+
+    private function getDataAsJsonElement(array $dataElement): string
+    {
+        $encoder = new JsonEncoder();
+        return $encoder->encode($dataElement, 'json');
     }
 
     /**

--- a/Tests/Unit/Api/FormDataApiDtoTest.php
+++ b/Tests/Unit/Api/FormDataApiDtoTest.php
@@ -22,4 +22,15 @@ class FormDataApiDtoTest extends TestCase
         self::assertSame($apiDto->getWebspace(), 'alengo');
     }
 
+    public function testApiDtoWithArray()
+    {
+        $apiDto = new FormData($this->generateFormDataWithArray(), 'en');
+
+        self::assertSame($apiDto->getData(), [['type' => 'field','data' => '{"1":"test"}', 'label' => 'arrayData'],['type' => 'field','data' => 'Oliver', 'label' => 'firstname']]);
+        self::assertSame($apiDto->getUserMail(), 'usertest@test.de');
+        self::assertSame($apiDto->getReceiverMail(), 'receivertest@test.de');
+        self::assertSame($apiDto->getLocale(), 'de');
+        self::assertSame($apiDto->getWebspace(), 'alengo');
+    }
+
 }

--- a/Tests/Unit/Traits/FormDataTrait.php
+++ b/Tests/Unit/Traits/FormDataTrait.php
@@ -20,4 +20,18 @@ trait FormDataTrait
 
         return $data;
     }
+
+    public function generateFormDataWithArray(): FormData
+    {
+        $data = new FormData();
+        $data->setWebspaceKey('alengo');
+        $data->setData(['firstname' => 'Oliver','arrayData' => ['1' => 'test']]);
+        $data->setUserMail('usertest@test.de');
+        $data->setReceiverMail('receivertest@test.de');
+        $data->setLocale('de');
+        $data->setCreated(new \DateTime());
+        $data->setChanged(new \DateTime());
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Allow now Arrays in Form Data.  As following example 

<img width="1061" alt="Bildschirmfoto 2022-10-05 um 17 35 03" src="https://user-images.githubusercontent.com/9395097/194101679-bbc13c02-47d8-4875-8447-a98e081ba0ba.png">
