### PR TITLE
Set missing Symfony 7 Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "handcraftedinthealps/zendsearch": "^2.0",
-        "jackalope/jackalope-doctrine-dbal": "^1.3.4",
-        "friendsofphp/php-cs-fixer": "^3.9",
+        "jackalope/jackalope-doctrine-dbal": "^1.3.4 || ^2.0",
+        "php-cs-fixer/shim": "^3.9",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-doctrine": "^1.3",


### PR DESCRIPTION
I have updated 2 libraries which are not directly related to the Symfony update. 
However, the still used version of `"jackalope/jackalope-doctrine-dbal" 1.3.4`, for example, requires Symfony Config 6.4, which is why you can still get outdated Symfony versions installed via this library.

As tipp @hual7 :
Check with `composer outdated` whether you have installed outdated packages. 
This is often the case, which is not a bad thing.
However, you can check whether, for example, a Symfony update is not complete